### PR TITLE
Track Most Recent Page, and Display Most Recent Page Results on the Main UI Thread

### DIFF
--- a/src/scraper/CurrentPageResult.java
+++ b/src/scraper/CurrentPageResult.java
@@ -24,7 +24,7 @@ public class CurrentPageResult {
         this.changed = changed;
     }
 
-    public boolean getChanged() {
+    public boolean isChanged() {
         return changed;
     }
 

--- a/src/scraper/CurrentPageResult.java
+++ b/src/scraper/CurrentPageResult.java
@@ -10,7 +10,7 @@ public class CurrentPageResult {
     private ArrayList<String> dates;
     private ArrayList<String> facebookLinks;
     private boolean changed = false; // so the UI thread can wait until CurrentPageResult has been updated to look at it again, rather than keep polling it's data
-    private boolean finalPage; // to let the program know that the final page has been reached
+    private boolean finalPage = false; // to let the program know that the final page has been reached
 
     public boolean isFinalPage() {
         return finalPage;

--- a/src/scraper/CurrentPageResult.java
+++ b/src/scraper/CurrentPageResult.java
@@ -9,6 +9,16 @@ public class CurrentPageResult {
     private ArrayList<String> emails;
     private ArrayList<String> dates;
     private ArrayList<String> facebookLinks;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    private String location = "";
     private boolean changed = false; // so the UI thread can wait until CurrentPageResult has been updated to look at it again, rather than keep polling it's data
     private boolean finalPage = false; // to let the program know that the final page has been reached
 

--- a/src/scraper/CurrentPageResult.java
+++ b/src/scraper/CurrentPageResult.java
@@ -9,6 +9,24 @@ public class CurrentPageResult {
     private ArrayList<String> emails;
     private ArrayList<String> dates;
     private ArrayList<String> facebookLinks;
+    private boolean changed = false; // so the UI thread can wait until CurrentPageResult has been updated to look at it again, rather than keep polling it's data
+    private boolean finalPage; // to let the program know that the final page has been reached
+
+    public boolean isFinalPage() {
+        return finalPage;
+    }
+
+    public void setFinalPage(boolean finalPage) {
+        this.finalPage = finalPage;
+    }
+
+    public void setChanged(boolean changed) {
+        this.changed = changed;
+    }
+
+    public boolean getChanged() {
+        return changed;
+    }
 
     public ArrayList<String> getInternalLinks() {
         return internalLinks;

--- a/src/scraper/GetHtml.java
+++ b/src/scraper/GetHtml.java
@@ -30,11 +30,11 @@ public class GetHtml {
                 Instant start = Instant.now();
                 String currentURL = urlsToDownload.poll(3, TimeUnit.SECONDS);
                 Document doc = Jsoup.connect(currentURL).get();
-                System.out.println("Getting HTML for: " + currentURL);
+                //System.out.println("Getting HTML for: " + currentURL);
                 Instant finish = Instant.now();
                 long sleepTime = getSleepTime(start, finish);
                 downloadedPages.add(doc);
-                System.out.println("Sleeping for miliseconds: " + sleepTime);
+                //System.out.println("Sleeping for miliseconds: " + sleepTime);
                 Thread.sleep(sleepTime);
             } catch (IOException | InterruptedException e) {
                 e.printStackTrace();

--- a/src/scraper/Program.java
+++ b/src/scraper/Program.java
@@ -33,10 +33,17 @@ public class Program {
         // to make sure that the scraper will start.
         Thread.sleep(10000);
 //        System.out.println(downloadedPages);
-        ScrapeHtml scrapeHtml = new ScrapeHtml(urlsToDownload, downloadedPages, syncedPaintedUrls);
+
+        CurrentPageResult mostCurrentPageResult = new CurrentPageResult();
+
+        ScrapeHtml scrapeHtml = new ScrapeHtml(urlsToDownload, downloadedPages, syncedPaintedUrls, mostCurrentPageResult);
         Thread thread1 = new Thread(scrapeHtml);
         Thread thread2 = new Thread(scrapeHtml);
         thread1.start();
         thread2.start();
+
+        while(!mostCurrentPageResult.isFinalPage()) {
+
+        }
     }
 }

--- a/src/scraper/Program.java
+++ b/src/scraper/Program.java
@@ -13,7 +13,7 @@ public class Program {
 
     // https://stackoverflow.com/questions/616484/how-to-use-concurrentlinkedqueue/616505
     public static void main(String[] args) throws InterruptedException {
-        final String START_URL = "https://touro.edu";
+        final String START_URL = "https://www.touro.edu/";
         LinkedBlockingQueue<Document> downloadedPages = new LinkedBlockingQueue<>();
         LinkedBlockingQueue<String> urlsToDownload = new LinkedBlockingQueue<>();
         Set<String> paintedUrls = new HashSet<>();
@@ -29,6 +29,9 @@ public class Program {
             }
         }.start();
 
+        // We need to color/paint the root
+        syncedPaintedUrls.add("https://www.touro.edu/");
+
         // This will not find anything and then just break out. find a better way.
         // to make sure that the scraper will start.
         Thread.sleep(10000);
@@ -42,18 +45,26 @@ public class Program {
         thread1.start();
         thread2.start();
 
+
         while(!mostCurrentPageResult.isFinalPage()) {
 
-            if(mostCurrentPageResult.isChanged()) {
-                // delete the previous results and display the most current ones
-                // we can clear the terminal and then print our new results (option 1)
+            synchronized(mostCurrentPageResult) {
+                if (mostCurrentPageResult.isChanged()) {
 
-                synchronized (mostCurrentPageResult) {
-                    mostCurrentPageResult.setChanged(false);
+                    // delete the previous results and display the most current ones
+                    // we can clear the terminal and then print our new results (option 1)
+                    for(int i = 0; i < 100; i++)
+                        System.out.println();
+
+                    System.out.println("URL of Webpage: ");
+                    System.out.println(mostCurrentPageResult.getLocation());
+
+                    synchronized (mostCurrentPageResult) {
+                        mostCurrentPageResult.setChanged(false);
+                    }
                 }
             }
         }
-
 
         // final page work
 

--- a/src/scraper/Program.java
+++ b/src/scraper/Program.java
@@ -13,7 +13,7 @@ public class Program {
 
     // https://stackoverflow.com/questions/616484/how-to-use-concurrentlinkedqueue/616505
     public static void main(String[] args) throws InterruptedException {
-        final String START_URL = "https://www.touro.edu/";
+        final String START_URL = "https://www.routine.co/";
         LinkedBlockingQueue<Document> downloadedPages = new LinkedBlockingQueue<>();
         LinkedBlockingQueue<String> urlsToDownload = new LinkedBlockingQueue<>();
         Set<String> paintedUrls = new HashSet<>();
@@ -44,6 +44,17 @@ public class Program {
 
         while(!mostCurrentPageResult.isFinalPage()) {
 
+            if(mostCurrentPageResult.isChanged()) {
+                for(int i = 0; i < 100; i++)
+                    System.out.println();
+            }
+
+            synchronized (mostCurrentPageResult) {
+                mostCurrentPageResult.setChanged(false);
+            }
         }
+
+        // final page work
+
     }
 }

--- a/src/scraper/Program.java
+++ b/src/scraper/Program.java
@@ -13,7 +13,7 @@ public class Program {
 
     // https://stackoverflow.com/questions/616484/how-to-use-concurrentlinkedqueue/616505
     public static void main(String[] args) throws InterruptedException {
-        final String START_URL = "https://www.routine.co/";
+        final String START_URL = "https://touro.edu";
         LinkedBlockingQueue<Document> downloadedPages = new LinkedBlockingQueue<>();
         LinkedBlockingQueue<String> urlsToDownload = new LinkedBlockingQueue<>();
         Set<String> paintedUrls = new HashSet<>();
@@ -45,14 +45,15 @@ public class Program {
         while(!mostCurrentPageResult.isFinalPage()) {
 
             if(mostCurrentPageResult.isChanged()) {
-                for(int i = 0; i < 100; i++)
-                    System.out.println();
-            }
+                // delete the previous results and display the most current ones
+                // we can clear the terminal and then print our new results (option 1)
 
-            synchronized (mostCurrentPageResult) {
-                mostCurrentPageResult.setChanged(false);
+                synchronized (mostCurrentPageResult) {
+                    mostCurrentPageResult.setChanged(false);
+                }
             }
         }
+
 
         // final page work
 

--- a/src/scraper/ScrapeHtml.java
+++ b/src/scraper/ScrapeHtml.java
@@ -30,7 +30,7 @@ public class ScrapeHtml implements Runnable {
         this.urlsToDownload = urlsToDownload;
         this.downloadedPages = downloadedPages;
         this.syncedPaintedUrls = syncedPaintedUrls;
-        this.mostCurrentPageResult = mostCurrentPageResult;
+        this.mostCurrentPageResult = mostRecentPage;
     }
 
     @Override
@@ -76,9 +76,9 @@ public class ScrapeHtml implements Runnable {
                 mostCurrentPageResult.setPhoneNumbers(phoneNumbers);
                 mostCurrentPageResult.setChanged(true);
             }
-
-            //parse for two non trivial
         }
+
+        mostCurrentPageResult.setFinalPage(true);
     }
 
     private ArrayList<String> getFacebookLinks(Document pageToParse) {

--- a/src/scraper/ScrapeHtml.java
+++ b/src/scraper/ScrapeHtml.java
@@ -53,9 +53,8 @@ public class ScrapeHtml implements Runnable {
             {
                 for (String url : internalLinks) {
 
-                    if (!syncedPaintedUrls.contains(url)) {
+                    if(syncedPaintedUrls.add(url))
                         urlsToDownload.add(url);
-                    }
                 }
             }
 
@@ -75,14 +74,17 @@ public class ScrapeHtml implements Runnable {
             ArrayList<String> facebookLinks = getFacebookLinks(pageToParse);
 
 
-            synchronized(mostCurrentPageResult) {
-                mostCurrentPageResult.setInternalLinks(internalLinks);
-                mostCurrentPageResult.setExternalLinks(externalLinks);
-                mostCurrentPageResult.setDates(dates);
-                mostCurrentPageResult.setEmails(emails);
-                mostCurrentPageResult.setFacebookLinks(facebookLinks);
-                mostCurrentPageResult.setPhoneNumbers(phoneNumbers);
-                mostCurrentPageResult.setChanged(true);
+            if (pageToParse != null) {
+                synchronized (mostCurrentPageResult) {
+                    mostCurrentPageResult.setLocation(pageToParse.location());
+                    mostCurrentPageResult.setInternalLinks(internalLinks);
+                    mostCurrentPageResult.setExternalLinks(externalLinks);
+                    mostCurrentPageResult.setDates(dates);
+                    mostCurrentPageResult.setEmails(emails);
+                    mostCurrentPageResult.setFacebookLinks(facebookLinks);
+                    mostCurrentPageResult.setPhoneNumbers(phoneNumbers);
+                    mostCurrentPageResult.setChanged(true);
+                }
             }
         }
 
@@ -218,9 +220,9 @@ public class ScrapeHtml implements Runnable {
         ArrayList<String> internalUrls = new ArrayList<>();
         links.stream().map((link) -> link.attr("abs:href")).forEachOrdered((url) -> {
             url = cleanedURL(url);
-            boolean add = syncedPaintedUrls.add(url);
+            boolean add = !syncedPaintedUrls.contains(url);
             if (add && isValidInternalURL(url)) {
-                System.out.println(url);
+                //System.out.println(url);
                 //confusing that this func doesnt just get links rather actually adds them to urlsToDownload queue
                 internalUrls.add(url);
             }

--- a/src/scraper/ScrapeHtml.java
+++ b/src/scraper/ScrapeHtml.java
@@ -23,12 +23,14 @@ public class ScrapeHtml implements Runnable {
     LinkedBlockingQueue<String> urlsToDownload;
     Set<String> paintedUrls = new HashSet<>();
     Set<String> syncedPaintedUrls;// all actions should be done through this one.
+    private CurrentPageResult mostCurrentPageResult;
     private String[] internalSites = new String[] {"touro.edu", "whatElseGoesHere"};
 
-    public ScrapeHtml(LinkedBlockingQueue<String> urlsToDownload, LinkedBlockingQueue<Document> downloadedPages, Set<String> syncedPaintedUrls) {
+    public ScrapeHtml(LinkedBlockingQueue<String> urlsToDownload, LinkedBlockingQueue<Document> downloadedPages, Set<String> syncedPaintedUrls, CurrentPageResult mostRecentPage) {
         this.urlsToDownload = urlsToDownload;
         this.downloadedPages = downloadedPages;
         this.syncedPaintedUrls = syncedPaintedUrls;
+        this.mostCurrentPageResult = mostCurrentPageResult;
     }
 
     @Override
@@ -48,6 +50,7 @@ public class ScrapeHtml implements Runnable {
             for (String url : internalLinks) {
                 urlsToDownload.add(url);
             }
+
             // set internalLinks to currentPage's internalLinks in sync block
             
             //external urls
@@ -62,7 +65,17 @@ public class ScrapeHtml implements Runnable {
             ArrayList<String> dates = getDates(pageToParse);  
 
             ArrayList<String> facebookLinks = getFacebookLinks(pageToParse);
-            
+
+
+            synchronized(mostCurrentPageResult) {
+                mostCurrentPageResult.setInternalLinks(internalLinks);
+                mostCurrentPageResult.setExternalLinks(externalLinks);
+                mostCurrentPageResult.setDates(dates);
+                mostCurrentPageResult.setEmails(emails);
+                mostCurrentPageResult.setFacebookLinks(facebookLinks);
+                mostCurrentPageResult.setPhoneNumbers(phoneNumbers);
+                mostCurrentPageResult.setChanged(true);
+            }
 
             //parse for two non trivial
         }


### PR DESCRIPTION
I've implemented a CurrentPageResult tracker, which seems to work across the threads in tandem. This allows the MAIN UI thread to do what it needs to do according to the specifications (Get most recent page, and display it's data to the user) I haven't shown all information, but at this point, that should be relatively trivial.

I've also commented out lines that were logging before, since at this point all UI activity should be done by the MAIN UI thread.